### PR TITLE
meta: Remove cache rust step

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -37,6 +37,11 @@ jobs:
       run: |
         new_version=`scripts/bumb_version.py ${{ inputs.bumpVersion }}`
         echo "new_version=$new_version" >> $GITHUB_OUTPUT
+    - name: Update lock file
+      uses: actions-rs/cargo@v1
+      with:
+        command: update
+        args: --package hoc
     - name: Create release branch
       id: crb
       run: |

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -91,8 +91,6 @@ jobs:
       with:
         toolchain: ${{ env.RUST_VERSION }}
         default: true
-    - name: Cache Rust
-      uses: Swatinem/rust-cache@v2
     - name: Build
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Caching is unnecessary for the create release workflow since the cache key will always be unique on each run (due to the Cargo.toml and Cargo.lock being changed on each release).